### PR TITLE
Do not escape special characters by default

### DIFF
--- a/src/__tests__/unicodeToLfs.test.ts
+++ b/src/__tests__/unicodeToLfs.test.ts
@@ -127,17 +127,53 @@ describe("unicodeToLfs", () => {
     ).toEqual("abc^Eì\x9A\0\0");
   });
 
-  it("should convert special characters to escape codes", () => {
-    expect(unicodeToLfs("| test |")).toEqual("^v test ^v");
-    expect(unicodeToLfs("* test *")).toEqual("^a test ^a");
-    expect(unicodeToLfs(": test :")).toEqual("^c test ^c");
-    expect(unicodeToLfs("\\ test \\")).toEqual("^d test ^d");
-    expect(unicodeToLfs("/ test /")).toEqual("^s test ^s");
-    expect(unicodeToLfs("? test ?")).toEqual("^q test ^q");
-    expect(unicodeToLfs('" test "')).toEqual("^t test ^t");
-    expect(unicodeToLfs("< test <")).toEqual("^l test ^l");
-    expect(unicodeToLfs("> test >")).toEqual("^r test ^r");
-    expect(unicodeToLfs("# test #")).toEqual("^h test ^h");
-    expect(unicodeToLfs("^ test ^")).toEqual("^^ test ^^");
+  it("should not convert any special characters to escape codes by default", () => {
+    expect(unicodeToLfs("| test |")).toEqual("| test |");
+    expect(unicodeToLfs("* test *")).toEqual("* test *");
+    expect(unicodeToLfs(": test :")).toEqual(": test :");
+    expect(unicodeToLfs("\\ test \\")).toEqual("\\ test \\");
+    expect(unicodeToLfs("/ test /")).toEqual("/ test /");
+    expect(unicodeToLfs("? test ?")).toEqual("? test ?");
+    expect(unicodeToLfs('" test "')).toEqual('" test "');
+    expect(unicodeToLfs("< test <")).toEqual("< test <");
+    expect(unicodeToLfs("> test >")).toEqual("> test >");
+    expect(unicodeToLfs("# test #")).toEqual("# test #");
+    expect(unicodeToLfs("^ test ^")).toEqual("^ test ^");
+  });
+
+  it("should convert special characters to escape codes if `shouldEscapeSpecialCharacters` is `true`", () => {
+    expect(
+      unicodeToLfs("| test |", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^v test ^v");
+    expect(
+      unicodeToLfs("* test *", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^a test ^a");
+    expect(
+      unicodeToLfs(": test :", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^c test ^c");
+    expect(
+      unicodeToLfs("\\ test \\", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^d test ^d");
+    expect(
+      unicodeToLfs("/ test /", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^s test ^s");
+    expect(
+      unicodeToLfs("? test ?", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^q test ^q");
+    expect(
+      unicodeToLfs('" test "', { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^t test ^t");
+    expect(
+      unicodeToLfs("< test <", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^l test ^l");
+    expect(
+      unicodeToLfs("> test >", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^r test ^r");
+    expect(
+      unicodeToLfs("# test #", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^h test ^h");
+    expect(
+      unicodeToLfs("^ test ^", { shouldEscapeSpecialCharacters: true })
+    ).toEqual("^^ test ^^");
   });
 });

--- a/src/codepageTables.ts
+++ b/src/codepageTables.ts
@@ -1,3 +1,5 @@
+import type { Codepage } from "./codepages";
+
 /**
  * Unicode to LFS codepage lookup tables
  *
@@ -5,7 +7,10 @@
  *
  * @internal
  */
-export const cpTables: Record<string, Record<number, number>> = {
+export const cpTables: Record<
+  `${Codepage}${string}`,
+  Record<number, number>
+> = {
   E: {
     8364: 128,
     8218: 130,

--- a/src/codepages.ts
+++ b/src/codepages.ts
@@ -1,0 +1,21 @@
+/**
+ * LFS codepage codes
+ *
+ * @internal
+ */
+export const codepages = [
+  "L",
+  "G",
+  "C",
+  "E",
+  "T",
+  "B",
+  "J",
+  "H",
+  "S",
+  "K",
+  "8",
+] as const;
+
+/** @internal */
+export type Codepage = (typeof codepages)[number];

--- a/src/unicodeToLfs.ts
+++ b/src/unicodeToLfs.ts
@@ -1,19 +1,5 @@
 import { cpTables } from "./codepageTables";
-
-const codepages = ["L", "G", "C", "E", "T", "B", "J", "H", "S", "K", "8"];
-
-const specials: Record<string, string> = {
-  "|": "^v",
-  "*": "^a",
-  ":": "^c",
-  "\\": "^d",
-  "/": "^s",
-  "?": "^q",
-  '"': "^t",
-  "<": "^l",
-  ">": "^r",
-  "#": "^h",
-};
+import { Codepage, codepages } from "./codepages";
 
 /**
  * Converts a Unicode string to an LFS-encoded string.
@@ -47,7 +33,7 @@ export function unicodeToLfs(
     }
   }
 
-  let currentCodepage = "^L";
+  let currentCodepage: Codepage = "L";
   let tempBytes = new Uint16Array(2);
   let tempCount;
   let index = 0;
@@ -131,7 +117,7 @@ export function unicodeToLfs(
     .join("");
 }
 
-function tryGetBytes(value: string, codepage: string): Uint16Array {
+function tryGetBytes(value: string, codepage: Codepage): Uint16Array {
   try {
     return getBytes(value, codepage);
   } catch (e) {
@@ -139,13 +125,13 @@ function tryGetBytes(value: string, codepage: string): Uint16Array {
   }
 }
 
-function getBytes(character: string, charset: string): Uint16Array {
+function getBytes(character: string, codepage: Codepage): Uint16Array {
   const charCode = character.charCodeAt(0);
 
   let data: Uint16Array | undefined = undefined;
 
   Object.entries(cpTables).every(([cp, charMap]) => {
-    if (!cp.startsWith(charset)) {
+    if (!cp.startsWith(codepage)) {
       return true;
     }
 
@@ -177,3 +163,16 @@ function getBytes(character: string, charset: string): Uint16Array {
 
   return data;
 }
+
+const specials: Record<string, string> = {
+  "|": "^v",
+  "*": "^a",
+  ":": "^c",
+  "\\": "^d",
+  "/": "^s",
+  "?": "^q",
+  '"': "^t",
+  "<": "^l",
+  ">": "^r",
+  "#": "^h",
+};

--- a/src/unicodeToLfs.ts
+++ b/src/unicodeToLfs.ts
@@ -25,21 +25,26 @@ export function unicodeToLfs(
   options: {
     isNullTerminated?: boolean;
     length?: number;
-  } = {
-    isNullTerminated: false,
-  }
+    shouldEscapeSpecialCharacters?: boolean;
+  } = {}
 ): string {
-  const { isNullTerminated, length } = options;
+  const {
+    isNullTerminated = false,
+    length,
+    shouldEscapeSpecialCharacters = false,
+  } = options;
 
   // Remove any existing language tags from the string
   value = value.split(new RegExp(`\\^[${codepages.join("")}]`)).join("");
 
-  // Escape ^ if not followed by a numeric colour code
-  value = value.split(/\^(?!\d)/).join("^^");
+  if (shouldEscapeSpecialCharacters) {
+    // Escape ^ if not followed by a numeric colour code
+    value = value.split(/\^(?!\d)/).join("^^");
 
-  // Escape special characters
-  for (let i in specials) {
-    value = value.split(i).join(specials[i]);
+    // Escape special characters
+    for (let i in specials) {
+      value = value.split(i).join(specials[i]);
+    }
   }
 
   let currentCodepage = "^L";


### PR DESCRIPTION
Introduced a new option `shouldEscapeSpecialCharacters`, which is set to `false` by default.

This will fix https://github.com/simbroadcasts/node-insim/issues/22 and https://github.com/simbroadcasts/node-insim/issues/24